### PR TITLE
[BUGFIX]  장바구니와 장바구니를 비교하고 있는 오류 수정

### DIFF
--- a/app/src/main/java/com/jjsh/smartshopping/domain/usecase/GetCartItemsUseCase.kt
+++ b/app/src/main/java/com/jjsh/smartshopping/domain/usecase/GetCartItemsUseCase.kt
@@ -23,9 +23,11 @@ class GetCartItemsUseCase @Inject constructor(
             Result.success(
                 if (checkItems.isEmpty()) cartItems.map { it.setInCheckList(false) }
                 else cartItems.map { item ->
-                    if (cartItems.find { it.productId == item.productId } == null)
+                    if (checkItems.find { it.productId == item.productId } == null) {
                         item.setInCheckList(false)
-                    else item
+                    } else {
+                        item
+                    }
                 }
             )
         }.catch {


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #75 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 장바구니와 장바구니를 비교하고 있는 오류 수정

예상대로 GetCartItemsUseCase에서 장바구니와 체크리스트를 비교하는 과정에서 장바구니에 있는 상품이 체크리스트에 있는지 확인해야하는 부분이 체크리스트가 아닌 장바구니에서 상품을 찾고 있는 오류를 발견, 수정 완

close #75 